### PR TITLE
Initial setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+BASE_URI=https://api.sandbox.ebay.com
+ACCESS_TOKEN=

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linux_tests:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [7.3, 7.4]
+        stability: [prefer-lowest, prefer-stable]
+
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, pcntl
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,6 @@
 name: tests
 
-on:
-  push:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   linux_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,4 +32,4 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: cp .env.example .env && vendor/bin/phpunit --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.env
+.idea
+.phpunit.result.cache
+composer.lock
+/test-reports
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": "^7.3",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.5",
         "guzzlehttp/guzzle-services": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     },
     "require": {
         "php": "^7.3",
-        "guzzlehttp/guzzle": "^6.5",
-        "guzzlehttp/guzzle-services": "^1.1"
+        "guzzlehttp/guzzle": "^7.1",
+        "guzzlehttp/guzzle-services": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^9.3.3",
         "php-vcr/php-vcr": "^1.5",
         "php-vcr/phpunit-testlistener-vcr": "dev-master",
         "allejo/php-vcr-sanitizer": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": "^7.3",
-        "guzzlehttp/guzzle": "^7.1",
+        "guzzlehttp/guzzle": "^6.5|^7.1",
         "guzzlehttp/guzzle-services": "^1.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests/"
+            "CoverGenius\\EbayRestPhpSdk\\Tests\\": "tests/"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.3",
         "guzzlehttp/guzzle": "^6.5|^7.1",
-        "guzzlehttp/guzzle-services": "^1.2"
+        "guzzlehttp/guzzle-services": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3.3",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "covergenius/ebay-rest-php-sdk",
+    "description": "https://developer.ebay.com/docs",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "jeff.nielsen",
+            "email": "jeff.n@covergenius.com"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "CoverGenius\\EbayRestPhpSdk\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "require": {
+        "php": "^7.3",
+        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle-services": "^1.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9",
+        "php-vcr/php-vcr": "^1.5",
+        "php-vcr/phpunit-testlistener-vcr": "dev-master",
+        "allejo/php-vcr-sanitizer": "dev-master",
+        "vlucas/phpdotenv": "^5.3"
+    },
+    "scripts": {
+        "test": "./vendor/bin/phpunit --colors=always -v --testdox"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,17 +8,12 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
+
   <testsuites>
     <testsuite name="Unit">
       <directory suffix="Test.php">./tests</directory>
     </testsuite>
   </testsuites>
-
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
 
   <listeners>
     <listener class="VCR\PHPUnit\TestListener\VCRTestListener"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+
+  <listeners>
+    <listener class="VCR\PHPUnit\TestListener\VCRTestListener"
+              file="vendor/php-vcr/phpunit-testlistener-vcr/src/VCRTestListener.php"/>
+  </listeners>
+</phpunit>

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,12 @@
 # Ebay REST PHP Sdk
 
+<p align="center">
+    <a href="https://github.com/CoverGenius/ebay-rest-php-sdk/actions"><img src="https://github.com/CoverGenius/ebay-rest-php-sdk/workflows/tests/badge.svg" alt="Build Status"></a>
+    <a href="https://packagist.org/packages/CoverGenius/ebay-rest-php-sdk"><img src="https://poser.pugx.org/CoverGenius/ebay-rest-php-sdk/d/total.svg" alt="Total Downloads"></a>
+    <a href="https://packagist.org/packages/CoverGenius/ebay-rest-php-sdk"><img src="https://poser.pugx.org/CoverGenius/ebay-rest-php-sdk/v/stable.svg" alt="Latest Stable Version"></a>
+    <a href="https://packagist.org/packages/CoverGenius/ebay-rest-php-sdk"><img src="https://poser.pugx.org/CoverGenius/ebay-rest-php-sdk/license.svg" alt="MIT license"></a>
+</p>
+
 ## Getting Started
 
 ### Requirements

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,10 @@
 # Ebay REST PHP Sdk
 
 ## Getting Started
-TBD
+
+```bash
+composer require covergenius/ebay-rest-php-sdk
+```
 
 ## Available APIs
 
@@ -51,4 +54,4 @@ composer test -- --group groupName
 ### VCR tests
 
 Note: You will need to generate a new access token and add it to the `EBAY_ACCESS_TOKEN` variable in your `.env` file. 
-Once you have a valid access token you can delete a vcr tape associated with the test you want to re-record.
+Using your valid access token, you may delete a vcr tape associated with the test you want to re-record.

--- a/readme.md
+++ b/readme.md
@@ -2,35 +2,66 @@
 
 ## Getting Started
 
+### Requirements
+
+* PHP ^7.3
+
+### Installation
+
+You can install this package by using Composer.
+
 ```bash
 composer require covergenius/ebay-rest-php-sdk
+```
+
+### Creating the client
+
+The `create()` method for the available APIs allows a config as an array to be passed to it. This accepts the typical 
+configuration that you would pass to the Guzzle client. See the Guzzle docs https://docs.guzzlephp.org/en/stable/quickstart.html
+
+```php
+use CoverGenius\EbayRestPhpSdk\Api\FulfillmentApi;
+
+$fulfillmentApi = FulfillmentApi::create([
+    'base_uri' => 'https://api.sandbox.ebay.com',
+    'headers' => [
+        'Authorization' => 'Bearer ACCESS_TOKEN',
+    ]
+]);
+```
+
+Alternatively, you can create a new GuzzleHttp Client instance to pass into the API class' constructor.
+
+```php
+use CoverGenius\EbayRestPhpSdk\Api\FulfillmentApi;
+use GuzzleHttp\Client;
+
+$client = new Client([
+    'base_uri' => 'https://api.sandbox.ebay.com',
+    'headers' => [
+        'Authorization' => 'Bearer ACCESS_TOKEN',
+    ]
+]);
+
+$fulfillmentApi = new FulfillmentApi($client);
 ```
 
 ## Available APIs
 
 ### Fulfillment API
 
-https://developer.ebay.com/api-docs/sell/fulfillment/static/overview.html
-
-* getOrder
-* issueRefund
+- https://developer.ebay.com/api-docs/sell/fulfillment/static/overview.html
 
 ## Accessing the response
 
 ```php
-<?php
-
 use CoverGenius\EbayRestPhpSdk\Api\FulfillmentApi;
 
-$fulfillmentApi = FulfillmentApi::create([
-    'headers' => [
-        'Authorization' => 'Bearer ACCESS_TOKEN',
-    ]
-]);
+$config = [];
 
-$order = $fulfillmentApi->getOrder([
-    'orderId' => 'ORDER_ID',
-]);
+$fulfillmentApi = FulfillmentApi::create($config);
+
+$order = $fulfillmentApi->getOrder(['orderId' => 'ORDER_ID']);
 
 // via getter
 $order->offsetGet('orderId');
@@ -41,9 +72,9 @@ $order['orderId'];
 
 ## Testing
 
-Run `composer test` to test all suites.
+### Running tests
 
-### Testing individual files or groups
+Run `composer test` to test all suites. Alternatively, you can run the commands below.
 
 ```bash
 composer test -- --filter testName
@@ -53,5 +84,15 @@ composer test -- --group groupName
 
 ### VCR tests
 
-Note: You will need to generate a new access token and add it to the `EBAY_ACCESS_TOKEN` variable in your `.env` file. 
+#### Important
+
+- You will need to generate a new access token and add it to the `EBAY_ACCESS_TOKEN` variable in your `.env` file. 
 Using your valid access token, you may delete a vcr tape associated with the test you want to re-record.
+  
+- Resource IDs such as the `orderId`, `refundId` etc. may need to be updated if they do not exist in the sandbox
+account you're using for re-recording tests.
+  
+#### Steps
+
+1. Delete the old VCR file associated with the test you want to re-record.
+2. Re-run your tests.

--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace CoverGenius\EbayRestPhpSdk;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Command\Guzzle\Description;
+use GuzzleHttp\Command\Guzzle\GuzzleClient;
+
+abstract class AbstractClient extends GuzzleClient
+{
+    /**
+     * EbayClient constructor. We setup our own constructor along with the parent
+     * GuzzleClient constructor to make this more testable. This will allow us
+     * to pass an instance of the Client with a mocked handler in our tests.
+     */
+    public function __construct(ClientInterface $client, array $config)
+    {
+        $baseUri = $client->getConfig('base_uri');
+
+        parent::__construct(
+            $client,
+            $this->buildDescription("$baseUri"),
+            null,
+            null,
+            null,
+            $config,
+        );
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public static function create(array $config = []): self
+    {
+        $headers = array_merge([
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+            'timeout' => 15,
+        ], $config);
+
+        return new static(new Client($headers), $config);
+    }
+
+    /**
+     * Build service description object
+     */
+    abstract protected function buildDescription(string $baseUri): Description;
+}

--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -14,7 +14,7 @@ abstract class AbstractClient extends GuzzleClient
      * GuzzleClient constructor to make this more testable. This will allow us
      * to pass an instance of the Client with a mocked handler in our tests.
      */
-    public function __construct(ClientInterface $client, array $config)
+    public function __construct(ClientInterface $client)
     {
         $baseUri = $client->getConfig('base_uri');
 
@@ -24,7 +24,7 @@ abstract class AbstractClient extends GuzzleClient
             null,
             null,
             null,
-            $config,
+            $client->getConfig(),
         );
     }
 
@@ -33,13 +33,13 @@ abstract class AbstractClient extends GuzzleClient
      */
     public static function create(array $config = []): self
     {
-        $headers = array_merge([
+        $configDefaults = array_merge([
             'Content-Type' => 'application/json',
             'Accept' => 'application/json',
             'timeout' => 15,
         ], $config);
 
-        return new static(new Client($headers), $config);
+        return new static(new Client($configDefaults));
     }
 
     /**

--- a/src/Api/FulfillmentApi.php
+++ b/src/Api/FulfillmentApi.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace CoverGenius\EbayRestPhpSdk\Api;
+
+use CoverGenius\EbayRestPhpSdk\AbstractClient;
+use GuzzleHttp\Command\Guzzle\Description;
+
+/**
+ * @method \GuzzleHttp\Command\Result getOrder(array $params)
+ * @method \GuzzleHttp\Command\Result issueRefund(array $params)
+ * @package CoverGenius\EbayRestPhpSdk\Api\FulfillmentApi
+ */
+class FulfillmentApi extends AbstractClient
+{
+    /**
+     * Refund reasons.
+     * - https://developer.ebay.com/api-docs/sell/fulfillment/types/api:ReasonForRefundEnum
+     */
+    const OTHER_ADJUSTMENT_REFUND_REASON = 'OTHER_ADJUSTMENT'; // If there is no specific reason.
+    const BUYER_CANCEL_REFUND_REASON = 'BUYER_CANCEL';
+    const SELLER_CANCEL_REFUND_REASON = 'SELLER_CANCEL';
+    const ITEM_NOT_RECEIVED_REFUND_REASON = 'ITEM_NOT_RECEIVED';
+    const BUYER_RETURN_REFUND_REASON = 'BUYER_RETURN';
+    const ITEM_NOT_AS_DESCRIBED_REFUND_REASON = 'ITEM_NOT_AS_DESCRIBED';
+    const SHIPPING_DISCOUNT_REFUND_REASON = 'SHIPPING_DISCOUNT';
+
+    /**
+     * Refund status. Ebay mentioned that the correct refund status to expect is "PENDING" because their API is async.
+     * - https://developer.ebay.com/api-docs/sell/fulfillment/types/sel:RefundStatusEnum
+     */
+    const FAILED_REFUND_STATUS = 'FAILED';
+    const PENDING_REFUND_STATUS = 'PENDING';
+    const REFUNDED_REFUND_STATUS = 'REFUNDED';
+
+    /**
+     * The possible payment states of an order, or in case of a refund request, the possible states of a buyer refund.
+     * - https://developer.ebay.com/api-docs/sell/fulfillment/types/sel:OrderPaymentStatusEnum
+     */
+    const FAILED_ORDER_PAYMENT_STATUS = 'FAILED';
+    const FULLY_REFUNDED_ORDER_PAYMENT_STATUS = 'FULLY_REFUNDED';
+    const PAID_ORDER_PAYMENT_STATUS = 'PAID';
+    const PARTIALLY_REFUNDED_ORDER_PAYMENT_STATUS = 'PARTIALLY_REFUNDED';
+    const PENDING_ORDER_PAYMENT_STATUS = 'PENDING';
+
+    /**
+     * Build service description object
+     */
+    protected function buildDescription(string $baseUri): Description
+    {
+        return new Description([
+            'baseUri' => $baseUri,
+            'operations' => [
+                'getOrder' => [
+                    'httpMethod' => 'GET',
+                    'uri' => '/sell/fulfillment/v1/order/{orderId}',
+                    'responseModel' => 'getResponse',
+                    'parameters' => [
+                        'orderId' => [
+                            'location' => 'uri',
+                            'type' => 'string',
+                            'required' => true,
+                        ],
+                    ]
+                ],
+                'issueRefund' => [
+                    'httpMethod' => 'POST',
+                    'uri' => '/sell/fulfillment/v1/order/{orderId}/issue_refund',
+                    'responseModel' => 'getResponse',
+                    'parameters' => [
+                        'orderId' => [
+                            'location' => 'uri',
+                            'type' => 'string',
+                            'required' => true,
+                        ],
+                        'reasonForRefund' => [
+                            'location' => 'json',
+                            'type' => 'string',
+                            'required' => true,
+                        ],
+                        'orderLevelRefundAmount' => [
+                            'location' => 'json',
+                            'type' => 'object',
+                            'required' => false,
+                            'properties' => [
+                                'value' => [
+                                    'type' => 'string',
+                                    'required' => true,
+                                ],
+                                'currency' => [
+                                    'type' => 'string',
+                                    'required' => true,
+                                ],
+                            ]
+                        ],
+                        'refundItems' => [
+                            'location' => 'json',
+                            'type' => 'array',
+                            'required' => false,
+                            'items' => [
+                                'type' => 'object',
+                                'required' => true,
+                                'properties' => [
+                                    'lineItemId' => [
+                                        'type' => 'string',
+                                        'required' => true,
+                                    ],
+                                    'refundAmount' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'value' => [
+                                                'type' => 'string',
+                                                'required' => true,
+                                            ],
+                                            'currency' => [
+                                                'type' => 'string',
+                                                'required' => true,
+                                            ],
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+            ],
+            'models' => [
+                'getResponse' => [
+                    'type' => 'object',
+                    'additionalProperties' => [
+                        'location' => 'json'
+                    ]
+                ]
+            ]
+        ]);
+    }
+}

--- a/tests/Unit/Api/FulfillmentApiTest.php
+++ b/tests/Unit/Api/FulfillmentApiTest.php
@@ -12,13 +12,11 @@ class FulfillmentApiTest extends TestCase
      */
     public function testGetOrder()
     {
-        var_dump($this->config());
-
         $order = FulfillmentApi::create($this->config())->getOrder([
-            'orderId' => 'ORDER_ID'
+            'orderId' => '09-06721-09981'
         ]);
 
-        $this->assertEquals('ORDER_ID', $order->offsetGet('orderId'));
+        $this->assertEquals('09-06721-09981', $order->offsetGet('orderId'));
     }
 
     /**
@@ -27,11 +25,15 @@ class FulfillmentApiTest extends TestCase
     public function testIssueRefund()
     {
         $refund = FulfillmentApi::create($this->config())->issueRefund([
-            'orderId' => 'ORDER_ID',
-            'reasonForRefund' => FulfillmentApi::OTHER_ADJUSTMENT_REFUND_REASON,
+            'orderId' => '09-06721-09981',
+            'reasonForRefund' => FulfillmentApi::BUYER_CANCEL_REFUND_REASON,
+            'orderLevelRefundAmount' => [
+                'currency' => 'USD',
+                'value' => '0.01',
+            ]
         ]);
 
-        $this->assertEquals('ORDER_ID', $refund->offsetGet('refundId'));
+        $this->assertEquals('5018168125', $refund->offsetGet('refundId'));
     }
 
     /**

--- a/tests/Unit/Api/FulfillmentApiTest.php
+++ b/tests/Unit/Api/FulfillmentApiTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Api;
+namespace CoverGenius\EbayRestPhpSdk\Tests\Unit\Api;
 
 use CoverGenius\EbayRestPhpSdk\Api\FulfillmentApi;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Api/FulfillmentApiTest.php
+++ b/tests/Unit/Api/FulfillmentApiTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\Api;
+
+use CoverGenius\EbayRestPhpSdk\Api\FulfillmentApi;
+use PHPUnit\Framework\TestCase;
+
+class FulfillmentApiTest extends TestCase
+{
+    /**
+     * @vcr fulfillment/get_order_success
+     */
+    public function testGetOrder()
+    {
+        var_dump($this->config());
+
+        $order = FulfillmentApi::create($this->config())->getOrder([
+            'orderId' => 'ORDER_ID'
+        ]);
+
+        $this->assertEquals('ORDER_ID', $order->offsetGet('orderId'));
+    }
+
+    /**
+     * @vcr fulfillment/issue_refund_success
+     */
+    public function testIssueRefund()
+    {
+        $refund = FulfillmentApi::create($this->config())->issueRefund([
+            'orderId' => 'ORDER_ID',
+            'reasonForRefund' => FulfillmentApi::OTHER_ADJUSTMENT_REFUND_REASON,
+        ]);
+
+        $this->assertEquals('ORDER_ID', $refund->offsetGet('refundId'));
+    }
+
+    /**
+     * Return config.
+     */
+    protected function config(): array
+    {
+        return [
+            'base_uri' => getenv('BASE_URI'),
+            'headers' => [
+                'Authorization' => 'Bearer ' . getenv('ACCESS_TOKEN'),
+            ],
+        ];
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,14 +5,12 @@ use VCR\VCR;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$dotEnv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../', '.env.example');
+$dotEnv = Dotenv\Dotenv::createUnsafeImmutable(__DIR__ . '/../', '.env');
 $dotEnv->load();
-
-var_dump(getenv('BASE_URI'));
 
 VCR::configure()
     ->setCassettePath(__DIR__ . '/../tests/vcr')
-    ->setStorage('json')
+    ->setStorage('yaml')
     ->enableLibraryHooks(['stream_wrapper', 'curl'])
     ->enableRequestMatchers(['method', 'url', 'host', 'body'])
     ->setMode('once');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,31 @@
+<?php
+
+use allejo\VCR\VCRCleaner;
+use VCR\VCR;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$dotEnv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../', '.env');
+$dotEnv->load();
+
+var_dump(getenv('BASE_URI'));
+
+VCR::configure()
+    ->setCassettePath(__DIR__ . '/../tests/vcr')
+    ->setStorage('json')
+    ->enableLibraryHooks(['stream_wrapper', 'curl'])
+    ->enableRequestMatchers(['method', 'url', 'host', 'body'])
+    ->setMode('once');
+
+VCRCleaner::enable([
+    'request' => [
+        'ignoreHeaders' => [
+            'X-Api-Key',
+            'Authorization',
+            'User-Agent',
+        ]
+    ]
+]);
+
+VCR::turnOn();
+VCR::turnOff();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,7 @@ use VCR\VCR;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$dotEnv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../', '.env');
+$dotEnv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../', '.env.example');
 $dotEnv->load();
 
 var_dump(getenv('BASE_URI'));

--- a/tests/vcr/fulfillment/get_order_success
+++ b/tests/vcr/fulfillment/get_order_success
@@ -1,0 +1,67 @@
+
+-
+    request:
+        method: GET
+        url: 'https://api.sandbox.ebay.com/sell/fulfillment/v1/order/09-06721-09981'
+        headers:
+            Host: ''
+            Accept-Encoding: ''
+            Authorization: ''
+            User-Agent: ''
+            Accept: ''
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            x-ebay-c-request-id: 'ri=KqX7bQKIbrjG,rci=979f731744310f70'
+            rlogid: 't6pithqauq%60%3F%3Ctofukqjtcpse*uww1u%28rbpv6770-1795f0e12c9-0x480cbc'
+            x-ebay-c-version: 1.11.0
+            x-ebay-client-tls-version: TLSv1.3
+            set-cookie: 'ebay=%5Esbf%3D%23%5E;Domain=.ebay.com;Path=/; Secure'
+            content-type: application/json
+            content-length: '3133'
+            date: 'Wed, 12 May 2021 05:30:28 GMT'
+            server: ebay-proxy-server
+            x-envoy-upstream-service-time: '208'
+            x-ebay-pop-id: UFES2-RNOAZ03-api
+        body: '{"orderId":"09-06721-09981","legacyOrderId":"313339508728-1105579625021","creationDate":"2021-03-12T00:34:01.000Z","lastModifiedDate":"2021-04-12T23:41:34.000Z","orderFulfillmentStatus":"NOT_STARTED","orderPaymentStatus":"PARTIALLY_REFUNDED","sellerId":"pymnts-test-001","buyer":{"username":"r_and_r_auctions","taxAddress":{"stateOrProvince":"AK","postalCode":"99577-7410","countryCode":"US"}},"pricingSummary":{"priceSubtotal":{"value":"8.04","currency":"USD"},"deliveryCost":{"value":"5.58","currency":"USD"},"deliveryDiscount":{"value":"-4.45","currency":"USD"},"tax":{"value":"0.27","currency":"USD"},"total":{"value":"9.44","currency":"USD"}},"cancelStatus":{"cancelState":"NONE_REQUESTED","cancelRequests":[]},"paymentSummary":{"totalDueSeller":{"value":"-0.84","currency":"USD"},"refunds":[{"refundDate":"2021-04-12T23:41:34.000Z","amount":{"value":"7.0","currency":"USD"},"refundStatus":"REFUNDED","refundReferenceId":"5014696222","refundId":"5014696222"},{"refundDate":"2021-04-12T23:27:17.000Z","amount":{"value":"1.0","currency":"USD"},"refundStatus":"REFUNDED","refundReferenceId":"5014694369","refundId":"5014694369"},{"refundDate":"2021-04-12T22:53:25.000Z","amount":{"value":"1.0","currency":"USD"},"refundStatus":"REFUNDED","refundReferenceId":"5014691687","refundId":"5014691687"}],"payments":[{"paymentMethod":"EBAY","paymentReferenceId":"420004_S","paymentDate":"2021-03-15T10:46:28.000Z","amount":{"value":"8.16","currency":"USD"},"paymentStatus":"PAID"}]},"fulfillmentStartInstructions":[{"fulfillmentInstructionsType":"SHIP_TO","minEstimatedDeliveryDate":"2021-03-17T07:00:00.000Z","maxEstimatedDeliveryDate":"2021-03-30T07:00:00.000Z","ebaySupportedFulfillment":false,"shippingStep":{"shipTo":{"fullName":"Ray Heraldo","contactAddress":{"addressLine1":"11246 Aurora St","city":"Eagle River","stateOrProvince":"AK","postalCode":"99577-7410","countryCode":"US"},"primaryPhone":{"phoneNumber":"4084390890"}},"shippingServiceCode":"Other"}}],"fulfillmentHrefs":[],"lineItems":[{"lineItemId":"10034704132409","legacyItemId":"313339508728","title":"PLEASE DO NOT BID - MP Testing - Make a donation, enable sales tax","lineItemCost":{"value":"8.04","currency":"USD"},"quantity":6,"soldFormat":"FIXED_PRICE","listingMarketplaceId":"EBAY_US","purchaseMarketplaceId":"EBAY_US","lineItemFulfillmentStatus":"NOT_STARTED","total":{"value":"9.44","currency":"USD"},"deliveryCost":{"shippingCost":{"value":"1.13","currency":"USD"},"discountAmount":{"value":"4.45","currency":"USD"}},"appliedPromotions":[],"taxes":[{"amount":{"value":"0.27","currency":"USD"}}],"refunds":[{"refundDate":"2021-04-12T23:41:34.000Z","refundId":"5014696222"},{"refundDate":"2021-04-12T23:27:17.000Z","refundId":"5014694369"},{"refundDate":"2021-04-12T22:53:25.000Z","refundId":"5014691687"}],"lineItemFulfillmentInstructions":{"minEstimatedDeliveryDate":"2021-03-17T07:00:00.000Z","maxEstimatedDeliveryDate":"2021-03-30T07:00:00.000Z","shipByDate":"2021-03-17T06:59:59.000Z","guaranteedDelivery":false}}],"salesRecordReference":"195","totalFeeBasisAmount":{"value":"9.44","currency":"USD"},"totalMarketplaceFee":{"value":"1.28","currency":"USD"}}'
+        curl_info:
+            url: 'https://api.sandbox.ebay.com/sell/fulfillment/v1/order/09-06721-09981'
+            content_type: application/json
+            http_code: 200
+            header_size: 473
+            request_size: 2383
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 0.777655
+            namelookup_time: 0.012749
+            connect_time: 0.01292
+            pretransfer_time: 0.352179
+            size_upload: !!float 0
+            size_download: !!float 3133
+            speed_download: !!float 4032
+            speed_upload: !!float 0
+            download_content_length: !!float 3133
+            upload_content_length: !!float -1
+            starttransfer_time: 0.777416
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 209.140.129.1
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 172.30.0.5
+            local_port: 41072
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 352028
+            connect_time_us: 12920
+            namelookup_time_us: 12749
+            pretransfer_time_us: 352179
+            redirect_time_us: 0
+            starttransfer_time_us: 777416
+            total_time_us: 777655

--- a/tests/vcr/fulfillment/issue_refund_success
+++ b/tests/vcr/fulfillment/issue_refund_success
@@ -1,0 +1,67 @@
+
+-
+    request:
+        method: POST
+        url: 'https://api.sandbox.ebay.com/sell/fulfillment/v1/order/09-06721-09981/issue_refund'
+        headers:
+            Host: ''
+            Expect: ''
+            Accept-Encoding: ''
+            Authorization: ''
+            User-Agent: ''
+            Content-Type: application/json
+            Accept: ''
+        body: '{"reasonForRefund":"BUYER_CANCEL","orderLevelRefundAmount":{"currency":"USD","value":"0.01"}}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            rlogid: 't6shrfgostwhciwdvn9%3Fuk%60uksbalrpqkbmqgwj%28l%60pam*w%60ut3522-1795f0e162e-0x235a'
+            x-ebay-client-tls-version: TLSv1.3
+            content-type: application/json
+            content-length: '50'
+            date: 'Wed, 12 May 2021 05:30:34 GMT'
+            x-envoy-upstream-service-time: '5439'
+            server: ebay-proxy-server
+            x-ebay-pop-id: UFES2-RNOAZ03-api
+        body: '{"refundId":"5018168125","refundStatus":"PENDING"}'
+        curl_info:
+            url: 'https://api.sandbox.ebay.com/sell/fulfillment/v1/order/09-06721-09981/issue_refund'
+            content_type: application/json
+            http_code: 200
+            header_size: 335
+            request_size: 2542
+            filetime: -1
+            ssl_verify_result: 0
+            redirect_count: 0
+            total_time: 5.957014
+            namelookup_time: 0.005253
+            connect_time: 0.005381
+            pretransfer_time: 0.339618
+            size_upload: !!float 93
+            size_download: !!float 50
+            speed_download: !!float 8
+            speed_upload: !!float 15
+            download_content_length: !!float 50
+            upload_content_length: !!float 93
+            starttransfer_time: 5.956961
+            redirect_time: !!float 0
+            redirect_url: ''
+            primary_ip: 209.140.129.1
+            certinfo: {  }
+            primary_port: 443
+            local_ip: 172.30.0.5
+            local_port: 41074
+            http_version: 2
+            protocol: 2
+            ssl_verifyresult: 0
+            scheme: HTTPS
+            appconnect_time_us: 339062
+            connect_time_us: 5381
+            namelookup_time_us: 5253
+            pretransfer_time_us: 339618
+            redirect_time_us: 0
+            starttransfer_time_us: 5956961
+            total_time_us: 5957014


### PR DESCRIPTION
**Added**

- readme
- github action (tests for php 7.3, 7.4 and does a composer update for lowest and highest dependency version)
- separated api classes based on their categories, eg the issueRefund and getOrder APIs belong to the ebay fulfillment api group. This will make it easier to maintain if we end up adding more apis for the public to use in this package.
- added tests

**Note**

- The composer dependencies are currently based on the one's in xpay. when we update the composer dependencies in xpay, the we can go ahead and update the dependencies in this sdk.